### PR TITLE
Update constants.ts to support image titles

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,6 +53,7 @@ export const allowedTags = {
     'id',
     'src',
     'style',
+    'title',
     'usemap',
     'vspace',
     'width',


### PR DESCRIPTION
To show cross-browser tooltips on images, such as file names, the title attribute is commonly used. At the moment this attribute is stripped, which means there's no way of showing the filename on an image.